### PR TITLE
fix containerport

### DIFF
--- a/charts/nl-portal-backend/templates/deployment.yaml
+++ b/charts/nl-portal-backend/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8081
               protocol: TCP
           {{- if .Values.livenessProbe.enabled }}
           {{- with .Values.livenessProbe }}


### PR DESCRIPTION
![Screenshot 2025-01-20 at 11 20 11](https://github.com/user-attachments/assets/4e897029-a3cd-402b-a602-3276b1c57828)

Currently, the chart is lying about which port the container opens. It's not port 80, it's 8081.