### PR TITLE
nl portal backend v2.0.2

### DIFF
--- a/charts/nl-portal-backend/nl-portal-backend/Chart.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.x.y
 description: Nl Portal backend Helm chart to be used in Kubernetes clusters.
 name: nl-portal-backend
 type: application
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   - name: postgresql

--- a/charts/nl-portal-backend/nl-portal-backend/README.md
+++ b/charts/nl-portal-backend/nl-portal-backend/README.md
@@ -1,6 +1,6 @@
 # nl-portal-backend
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.x.y](https://img.shields.io/badge/AppVersion-2.x.y-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.x.y](https://img.shields.io/badge/AppVersion-2.x.y-informational?style=flat-square)
 
 Nl Portal backend Helm chart to be used in Kubernetes clusters.
 
@@ -36,6 +36,8 @@ Nl Portal backend Helm chart to be used in Kubernetes clusters.
 | ingress.tls | list | `[]` |  |
 | livenessProbe.enabled | bool | `true` |  |
 | livenessProbe.failureThreshold | int | `6` |  |
+| livenessProbe.httpGet.path | string | `"/graphql?query=%7B__typename%7D"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
 | livenessProbe.initialDelaySeconds | int | `120` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
@@ -47,6 +49,8 @@ Nl Portal backend Helm chart to be used in Kubernetes clusters.
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `6` |  |
+| readinessProbe.httpGet.path | string | `"/graphql?query=%7B__typename%7D"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
 | readinessProbe.initialDelaySeconds | int | `120` |  |
 | readinessProbe.periodSeconds | int | `10` |  |
 | readinessProbe.successThreshold | int | `1` |  |
@@ -96,6 +100,10 @@ Nl Portal backend Helm chart to be used in Kubernetes clusters.
 | settings.services.payment.ogone.properties.configurations.belastingzaken.shaOutKey | string | `""` | If using existingSecret, set via key: NLPORTAL_CONFIG_PAYMENT_OGONE_PROPERTIES_CONFIGURATIONS_BELASTINGZAKEN_SHAOUTKEY |
 | settings.services.payment.ogone.properties.shaOutParameters | string | `""` | If using existingSecret, set via key: NLPORTAL_CONFIG_PAYMENT_OGONE_PROPERTIES_SHAOUTPARAMETERS |
 | settings.services.zakenapi.properties.secret | string | `""` | If using existingSecret, set via key: NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_SECRET |
+| startupProbe.failureThreshold | int | `90` |  |
+| startupProbe.httpGet.path | string | `"/graphql?query=%7B__typename%7D"` |  |
+| startupProbe.httpGet.port | string | `"http"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/nl-portal-backend/nl-portal-backend/templates/configmap.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/templates/configmap.yaml
@@ -84,10 +84,11 @@ data:
 
   # HaalCentraal BRP
   NLPORTAL_CONFIG_HAALCENTRAAL_BRP_ENABLED: {{ .Values.settings.services.haalcentraal_brp.enabled | quote }}
+  {{- if .Values.settings.services.haalcentraal_brp.enabled }} 
   NLPORTAL_CONFIG_HAALCENTRAAL_BRP_PROPERTIES_URL: {{ .Values.settings.services.haalcentraal_brp.properties.url | quote }}
   NLPORTAL_CONFIG_HAALCENTRAAL_BRP_PROPERTIES_SSL_ENABLED: {{ .Values.settings.services.haalcentraal_brp.properties.ssl.enabled | quote }}
   NLPORTAL_CONFIG_HAALCENTRAAL_BRP_PROPERTIES_SSL_KEY_CERTCHAIN: {{ .Values.settings.services.haalcentraal_brp.properties.ssl.key.certChain | quote }}
-
+  {{- end }}
   # HaalCentraal HR
   NLPORTAL_CONFIG_HAALCENTRAAL_HR_ENABLED: {{ .Values.settings.services.haalcentraal_hr.enabled | quote }}
   NLPORTAL_CONFIG_HAALCENTRAAL_HR_PROPERTIES_URL: {{ .Values.settings.services.haalcentraal_hr.properties.url | quote }}

--- a/charts/nl-portal-backend/nl-portal-backend/templates/deployment.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/templates/deployment.yaml
@@ -51,18 +51,21 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if .Values.livenessProbe.enabled }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+
           {{- with .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- end }}
+
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/nl-portal-backend/nl-portal-backend/values.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/values.yaml
@@ -58,8 +58,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+startupProbe:
+  httpGet:
+    path: /graphql?query=%7B__typename%7D
+    port: http
+  failureThreshold: 90
+  periodSeconds: 10
 livenessProbe:
   enabled: true
+  httpGet:
+    path: /graphql?query=%7B__typename%7D
+    port: http
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 1
@@ -68,6 +77,9 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
+  httpGet:
+    path: /graphql?query=%7B__typename%7D
+    port: http
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 1


### PR DESCRIPTION
- Adds startup probes
- Add endpoints to readiness/liveness probes
- Disable ` NLPORTAL_CONFIG_HAALCENTRAAL_BRP_PROPERTIES_*` entirely if not enabled