### PR TITLE
Fix secret encoding: Use stringData for better user experience

### DIFF
--- a/charts/nl-portal-backend/nl-portal-backend/templates/secret.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "nl-portal-backend.labels" . | nindent 4 }}
 type: Opaque
-data:
+stringData:
   # Database
   DATABASE_PASSWORD: {{ .Values.settings.database.password | quote }}
 


### PR DESCRIPTION
**Problem:**
The current implementation expects users to provide base64-encoded values in their values.yaml files, which creates a poor developer experience and makes configuration files unreadable.

**Solution:**
Changed from data to stringData in the secret template, allowing users to provide plain text values while Kubernetes handles base64 encoding automatically.

**Benefits:**
- Users can now provide readable, plain text secrets in their values files
- Eliminates the need for manual base64 encoding
- Improves maintainability and debugging experience
 - Follows Kubernetes best practices for string-based secrets

**Example:**
Users can now write:

```
settings:
  database:
    password: "mySecretPassword123"
```

Instead of having to provide base64-encoded values.