### PR TITLE
fix: move openzaak secret to secret

### DIFF
--- a/charts/nl-portal-backend/nl-portal-backend/templates/configmap.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/templates/configmap.yaml
@@ -60,7 +60,6 @@ data:
   NLPORTAL_CONFIG_ZAKENAPI_ENABLED: {{ .Values.settings.services.zakenapi.enabled | quote }}
   NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_URL: {{ .Values.settings.services.zakenapi.properties.url | quote }}
   NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_CLIENTID: {{ .Values.settings.services.zakenapi.properties.clientId | quote }}
-  NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_SECRET: {{ .Values.settings.services.zakenapi.properties.secret | quote }}
   NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_ZAAKDOCUMENTENCONFIG_VERTROUWELIJKHEIDSAANDUIDINGWHITELIST: {{ .Values.settings.services.zakenapi.properties.zaakdocumentenConfig.vertouwelijkheidsaanduidingWhitelist | quote }}
   NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_ZAAKDOCUMENTENCONFIG_STATUSWHITELIST: {{ .Values.settings.services.zakenapi.properties.zaakdocumentenConfig.statusWhitelist | quote }}
 

--- a/charts/nl-portal-backend/nl-portal-backend/templates/secret.yaml
+++ b/charts/nl-portal-backend/nl-portal-backend/templates/secret.yaml
@@ -23,6 +23,9 @@ data:
   NLPORTAL_CONFIG_DOCUMENTENAPIS_PROPERTIES_CONFIGURATIONS_OPENZAAK_SECRET: {{ .Values.settings.services.documentenapis.properties.configurations.openzaak.secret | quote }}
   NLPORTAL_CONFIG_DOCUMENTENAPIS_PROPERTIES_CONFIGURATIONS_DUMMYDOC_SECRET: {{ .Values.settings.services.documentenapis.properties.configurations.dummydoc.secret | quote }}
 
+  # ZakenAPI
+  NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_SECRET: {{ .Values.settings.services.zakenapi.properties.secret | quote }}
+
   # ObjectenAPI
   NLPORTAL_CONFIG_OBJECTENAPI_PROPERTIES_TOKEN: {{ .Values.settings.services.objectenapi.properties.token | quote }}
 


### PR DESCRIPTION
This change makes sure the secret `NLPORTAL_CONFIG_ZAKENAPI_PROPERTIES_SECRET` is stored in a secret.