### PR TITLE
feat: add extraEnvVars to nl-portal-frontend

### DIFF
--- a/charts/nl-portal-frontend/nl-portal-frontend/Chart.yaml
+++ b/charts/nl-portal-frontend/nl-portal-frontend/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.x.y
 description: Nl Portal frontend Helm chart to be used in Kubernetes clusters.
 name: nl-portal-frontend
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/nl-portal-frontend/nl-portal-frontend/README.md
+++ b/charts/nl-portal-frontend/nl-portal-frontend/README.md
@@ -1,6 +1,6 @@
 # nl-portal-frontend
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.x.y](https://img.shields.io/badge/AppVersion-2.x.y-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.x.y](https://img.shields.io/badge/AppVersion-2.x.y-informational?style=flat-square)
 
 Nl Portal frontend Helm chart to be used in Kubernetes clusters.
 
@@ -14,6 +14,7 @@ Nl Portal frontend Helm chart to be used in Kubernetes clusters.
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | existingSecret | string | `nil` |  |
+| extraEnvVars | list | `[]` | Optionally specify extra list of additional volumes |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"nginx"` |  |

--- a/charts/nl-portal-frontend/nl-portal-frontend/templates/deployment.yaml
+++ b/charts/nl-portal-frontend/nl-portal-frontend/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "nl-portal-frontend.fullname" . }}
+          env:
+            {{- if .Values.extraEnvVars }}
+            {{- include "nl-portal-frontend.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8081

--- a/charts/nl-portal-frontend/nl-portal-frontend/values.yaml
+++ b/charts/nl-portal-frontend/nl-portal-frontend/values.yaml
@@ -96,6 +96,15 @@ affinity: {}
 
 existingSecret: null
 
+# -- Array with extra environment variables to add
+# e.g:
+# extraEnvVars:
+#   - name: FOO
+#     value: "bar"
+
+# -- Optionally specify extra list of additional volumes
+extraEnvVars: []
+
 # -- Application Settings
 settings:
   oidc:
@@ -142,7 +151,7 @@ settings:
         showCurrentCasesPreview: true
         # -- TODO: add explanation, confirm that `1` is an OK default
         currentCasesPreviewLength: 1
-        
+
     services:
       # -- TODO: add explanation
       openKlantVersion: null


### PR DESCRIPTION
To be able to pass on env vars not specified in the configmap