### PR TITLE
cicd: git pull before pushing to minimize "must pull before pushing" conflicts

### DIFF
--- a/.github/workflows/nl-portal-backend-pr.yaml
+++ b/.github/workflows/nl-portal-backend-pr.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - "charts/nl-portal-backend/**"
 
+concurrency:
+  group: pr-readme-push-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/nl-portal-backend-pr.yaml
+++ b/.github/workflows/nl-portal-backend-pr.yaml
@@ -51,6 +51,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "README is up-to-date. No changes to commit."
           else
+            git pull
             git commit -m "Update README.md automatically via GitHub Actions"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi

--- a/.github/workflows/nl-portal-configpanel-backend-pr.yaml
+++ b/.github/workflows/nl-portal-configpanel-backend-pr.yaml
@@ -53,6 +53,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "README is up-to-date. No changes to commit."
           else
+            git pull
             git commit -m "Update README.md automatically via GitHub Actions"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi

--- a/.github/workflows/nl-portal-configpanel-backend-pr.yaml
+++ b/.github/workflows/nl-portal-configpanel-backend-pr.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - "charts/nl-portal-configpanel-backend/**"
 
+concurrency:
+  group: pr-readme-push-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/nl-portal-configpanel-frontend-pr.yaml
+++ b/.github/workflows/nl-portal-configpanel-frontend-pr.yaml
@@ -53,6 +53,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "README is up-to-date. No changes to commit."
           else
+            git pull
             git commit -m "Update README.md automatically via GitHub Actions"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi

--- a/.github/workflows/nl-portal-configpanel-frontend-pr.yaml
+++ b/.github/workflows/nl-portal-configpanel-frontend-pr.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - "charts/nl-portal-configpanel-frontend/**"
 
+concurrency:
+  group: pr-readme-push-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/nl-portal-frontend-pr.yaml
+++ b/.github/workflows/nl-portal-frontend-pr.yaml
@@ -53,6 +53,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "README is up-to-date. No changes to commit."
           else
+            git pull
             git commit -m "Update README.md automatically via GitHub Actions"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi

--- a/.github/workflows/nl-portal-frontend-pr.yaml
+++ b/.github/workflows/nl-portal-frontend-pr.yaml
@@ -6,6 +6,10 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "charts/nl-portal-frontend/**"
+concurrency:
+  group: pr-readme-push-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
 jobs:
   helm-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR workflow regenerates the README and pushes it if the PR-opener didn't do so.

But this push can fail if multiple of these PR workflows attempt to push at the same time; one of them will get a "must pull changes before pushing yours" error and fail.

By adding a `git pull` right before pushing and a concurrency group preventing multiple workflows from pushing at the same time, we can prevent this.